### PR TITLE
Possible Fix for Regular Shield penning Guns being able to pen the shield of Marshal Shields

### DIFF
--- a/lua/sc/tweak_data/charactertweakdata.lua
+++ b/lua/sc/tweak_data/charactertweakdata.lua
@@ -3312,7 +3312,8 @@ function CharacterTweakData:_init_marshal_shield(presets)
 	self.marshal_shield = deep_clone(presets.base)
 	self.marshal_shield.tags = {
 		"law",
-		"shield"
+		"shield", 
+		"shield_titan" -- added tag so that the shield of the marshal shield is considered a titan-shield
 	}
 	self.marshal_shield.experience = {}
 	self.marshal_shield.weapon = deep_clone(presets.weapon.normal)


### PR DESCRIPTION
idk if it is intended for guns without the ability to pen titan shields to pen us marshal shields

This "possible" fix prevents non-titan shield guns from penning us marshal shields and only guns that pen titan-shield to pen us marshal shields.